### PR TITLE
Implement custom camera view to support device orientation changes

### DIFF
--- a/endercv/src/main/java/org/corningrobotics/enderbots/endercv/CustomCameraView.java
+++ b/endercv/src/main/java/org/corningrobotics/enderbots/endercv/CustomCameraView.java
@@ -1,0 +1,99 @@
+package org.corningrobotics.enderbots.endercv;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.util.Log;
+
+import org.opencv.
+import org.opencv.android.JavaCameraView;
+import org.opencv.android.Utils;
+import org.opencv.core.Core;
+import org.opencv.core.Mat;
+
+/**
+ * Created by daniel on 11/11/17.
+ */
+
+public class CustomCameraView extends JavaCameraView {
+    private static final String TAG = "CustomCameraView";
+
+    public CustomCameraView(Context context, int cameraId) {
+        super(context, cameraId);
+    }
+
+    @Override
+    protected void deliverAndDrawFrame(CvCameraViewFrame frame) {
+        Mat modified;
+
+        int deviceOrientation = getContext().getResources().getConfiguration().orientation;
+
+        if (mListener != null) {
+            modified = mListener.onCameraFrame(frame);
+        } else {
+            modified = frame.rgba();
+        }
+
+        // rotate matrix for portrait orientation
+        if(deviceOrientation == Configuration.ORIENTATION_PORTRAIT) {
+            Core.rotate(modified, modified, Core.ROTATE_90_COUNTERCLOCKWISE);
+            // todo: might need to rotate the other way here for front camera
+        }
+
+        boolean bmpValid = true;
+        if (modified != null) {
+            try {
+                Utils.matToBitmap(modified, mCacheBitmap);
+            } catch(Exception e) {
+                Log.e(TAG, "Mat type: " + modified);
+                Log.e(TAG, "Bitmap type: " + mCacheBitmap.getWidth() + "*" + mCacheBitmap.getHeight());
+                Log.e(TAG, "Utils.matToBitmap() throws an exception: " + e.getMessage());
+                bmpValid = false;
+            }
+        }
+
+        if (bmpValid && mCacheBitmap != null) {
+            Canvas canvas = getHolder().lockCanvas();
+            if (canvas != null) {
+                canvas.drawColor(0, android.graphics.PorterDuff.Mode.CLEAR);
+                if (BuildConfig.DEBUG)
+                    Log.d(TAG, "mStretch value: " + mScale);
+
+                // maximize size of the bitmap to remove black borders in portrait orientation
+                mCacheBitmap = Bitmap.createScaledBitmap(mCacheBitmap, canvas.getHeight(), canvas.getWidth(), true);
+
+                if (mScale != 0) {
+                    canvas.drawBitmap(mCacheBitmap, new Rect(0,0,mCacheBitmap.getWidth(), mCacheBitmap.getHeight()),
+                            new Rect((int)((canvas.getWidth() - mScale*mCacheBitmap.getWidth()) / 2),
+                                    (int)((canvas.getHeight() - mScale*mCacheBitmap.getHeight()) / 2),
+                                    (int)((canvas.getWidth() - mScale*mCacheBitmap.getWidth()) / 2 + mScale*mCacheBitmap.getWidth()),
+                                    (int)((canvas.getHeight() - mScale*mCacheBitmap.getHeight()) / 2 + mScale*mCacheBitmap.getHeight())), null);
+                } else {
+                    canvas.drawBitmap(mCacheBitmap, new Rect(0,0,mCacheBitmap.getWidth(), mCacheBitmap.getHeight()),
+                            new Rect((canvas.getWidth() - mCacheBitmap.getWidth()) / 2,
+                                    (canvas.getHeight() - mCacheBitmap.getHeight()) / 2,
+                                    (canvas.getWidth() - mCacheBitmap.getWidth()) / 2 + mCacheBitmap.getWidth(),
+                                    (canvas.getHeight() - mCacheBitmap.getHeight()) / 2 + mCacheBitmap.getHeight()), null);
+                }
+
+                // temporarily rotate canvas to draw FPS meter in correct orientation in portrait
+                if(deviceOrientation == Configuration.ORIENTATION_PORTRAIT) {
+                    canvas.save();
+
+                    canvas.rotate(-90, getWidth() / 2, getHeight() / 2);
+
+                    if (mFpsMeter != null) {
+                        mFpsMeter.measure();
+                        mFpsMeter.draw(canvas, 20, 30);
+                    }
+
+                    canvas.restore();
+                }
+
+                getHolder().unlockCanvasAndPost(canvas);
+            }
+        }
+    }
+}

--- a/endercv/src/main/java/org/corningrobotics/enderbots/endercv/OpenCVPipeline.java
+++ b/endercv/src/main/java/org/corningrobotics/enderbots/endercv/OpenCVPipeline.java
@@ -17,7 +17,7 @@ public abstract class OpenCVPipeline implements CameraBridgeViewBase.CvCameraVie
     static {
         System.loadLibrary("opencv_java3");
     }
-    private JavaCameraView cameraView;
+    private CustomCameraView cameraView;
     private ViewDisplay viewDisplay;
     private Context context;
     private boolean initStarted = false;
@@ -51,7 +51,7 @@ public abstract class OpenCVPipeline implements CameraBridgeViewBase.CvCameraVie
             @Override
             public void run() {
                 // JCVs must be instantiated on a UI thread
-                cameraView = new JavaCameraView(finalContext, cameraIndex);
+                cameraView = new CustomCameraView(finalContext, cameraIndex);
                 cameraView.setCameraIndex(cameraIndex);
                 cameraView.setCvCameraViewListener(self);
                 inited = true;

--- a/openCVLibrary320/src/main/java/org/opencv/android/CameraBridgeViewBase.java
+++ b/openCVLibrary320/src/main/java/org/opencv/android/CameraBridgeViewBase.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.opencv.BuildConfig;
 import org.opencv.R;
+import org.opencv.core.Core;
 import org.opencv.core.Mat;
 import org.opencv.core.Size;
 
@@ -11,6 +12,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.res.Configuration;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -35,8 +37,6 @@ public abstract class CameraBridgeViewBase extends SurfaceView implements Surfac
     private static final int STARTED = 1;
 
     private int mState = STOPPED;
-    private Bitmap mCacheBitmap;
-    private CvCameraViewListener2 mListener;
     private boolean mSurfaceExist;
     private Object mSyncObject = new Object();
 
@@ -49,6 +49,8 @@ public abstract class CameraBridgeViewBase extends SurfaceView implements Surfac
     protected int mCameraIndex = CAMERA_ID_ANY;
     protected boolean mEnabled;
     protected FpsMeter mFpsMeter = null;
+    protected CvCameraViewListener2 mListener;
+    protected Bitmap mCacheBitmap;
 
     public static final int CAMERA_ID_ANY   = -1;
     public static final int CAMERA_ID_BACK  = 99;


### PR DESCRIPTION
Hello,

This pull-request implements a class, namely `CustomCameraView`, that extends `JavaCameraView` and overrides the method `deliverAndDrawFrame()` inherited from `CameraBridgeViewBase`. The implementation of this method has been changed to rotate the OpenCV `Mat` currently being processed using `Core.rotate()` only if the device orientation has changed. I should note that the `Mat` may need to be rotated 270 degrees instead of 90 if the front camera is being used. As a result of the FPS meter being unfortunately directly drawn to the surface view bitmap, it is necessary to separately rotate the FPS meter.

Please note: The changes in this pull-request haven't been tested as I don't have access to phones.