### PR TITLE
Fix obsolete configuration

### DIFF
--- a/endercv/build.gradle
+++ b/endercv/build.gradle
@@ -21,6 +21,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':openCVLibrary3')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':openCVLibrary3')
 }


### PR DESCRIPTION
"Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'. It will be removed at the end of 2018."